### PR TITLE
Displaycore fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ ignore = [
   "INP001",   # File is part of an implicit namespace package. (Just a bit unnecessary)
   "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
   "RUF005",   # collection-literal-concatenation
+  "FBT001",   # A function taking a sinlge bool value is very common.
 
   # MH uses commented out code in the build process:
   "ERA",   # Found commented-out code

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -50,9 +50,9 @@ from lib.hydra.i18n import I18n
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ _CONSTANTS: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-_MH_DISPLAY_WIDTH = const(320)
-_MH_DISPLAY_HEIGHT = const(240)
-_MH_DISPLAY_BACKLIGHT = const(42)
+_MH_DISPLAY_WIDTH = const(240)
+_MH_DISPLAY_HEIGHT = const(135)
+_MH_DISPLAY_BACKLIGHT = const(38)
 
 _DISPLAY_WIDTH_HALF = const(_MH_DISPLAY_WIDTH//2)
 
@@ -87,6 +87,7 @@ _APPNAME_Y = const(_ICON_Y + _ICON_HEIGHT + _Y_PADDING)
 
 
 _SCROLL_ANIMATION_TIME = const(400)
+_SCROLL_ANIMATION_QUICK = const(250)
 
 
 _ASCII_MAX = const(128)
@@ -492,6 +493,7 @@ class IconWidget:
         self.x = _DISPLAY_WIDTH_HALF
         self.prev_x = 0
         self.scroll_start_ms = time.ticks_ms()
+        self.anim = _SCROLL_ANIMATION_TIME
         self.force_update()
 
         # buffer for storing one custom icon
@@ -531,7 +533,7 @@ class IconWidget:
         fac = time.ticks_diff(
             time.ticks_ms(),
             self.scroll_start_ms,
-            ) / _SCROLL_ANIMATION_TIME
+            ) / self.anim_time
 
         if fac >= 1:
             self.direction = 0
@@ -548,6 +550,9 @@ class IconWidget:
         """Initialize the scrolling animation."""
         if self.next_icon != self.drawn_icon:
             self.force_update()
+            self.anim_time = _SCROLL_ANIMATION_QUICK
+        else:
+            self.anim_time = _SCROLL_ANIMATION_TIME
 
         draw_scrollbar()
         draw_app_name()
@@ -799,19 +804,19 @@ def main_loop():
         new_keys = KB.get_new_keys()
 
         # mh_if CARDPUTER:
-        # # Cardputer should use extended movement keys in the launcher
-        # KB.ext_dir_keys(new_keys)
+        # Cardputer should use extended movement keys in the launcher
+        KB.ext_dir_keys(new_keys)
         # mh_end_if
 
         # mh_if touchscreen:
-        # add swipes to direcitonal input
-        touch_events = KB.get_touch_events()
-        for event in touch_events:
-            if hasattr(event, 'direction'):
-                if event.direction == 'RIGHT':
-                    new_keys.append('LEFT')
-                elif event.direction == 'LEFT':
-                    new_keys.append('RIGHT')
+        # # add swipes to direcitonal input
+        # touch_events = KB.get_touch_events()
+        # for event in touch_events:
+        #     if hasattr(event, 'direction'):
+        #         if event.direction == 'RIGHT':
+        #             new_keys.append('LEFT')
+        #         elif event.direction == 'LEFT':
+        #             new_keys.append('RIGHT')
         # mh_end_if
 
         if new_keys:
@@ -918,6 +923,9 @@ def main_loop():
 
         if SYNCING_CLOCK:
             try_sync_clock()
+
+        # short sleep makes the animation look a little less flickery
+        time.sleep_ms(5)
 
 
 # run the main loop!

--- a/src/lib/display/displaycore.py
+++ b/src/lib/display/displaycore.py
@@ -18,13 +18,33 @@ class DisplayCore:
 
     def __init__(
             self,
-            width,
-            height,
-            rotation=0,
-            use_tiny_buf=False,
-            reserved_bytearray=None,
-            needs_swap=True,
-            **kwargs):
+            width: int,
+            height: int,
+            *,
+            rotation: int = 0,
+            use_tiny_buf: bool = False,
+            reserved_bytearray: bytearray|None = None,
+            needs_swap: bool = True,
+            **kwargs):  # noqa: ARG002
+        """Create the DisplayCore.
+
+        Args:
+            width (int): display width
+            height (int): display height
+        Kwargs:
+            rotation (int):
+                How to rotate the framebuffer (Default 0)
+            use_tiny_buf (bool):
+                Whether or not to use a smaller, 4bit framebuffer (rather than 16 bit).
+                If True, frame is stored in 4bits and converted line-by-line when `show` is called.
+            reserved_bytearray (bytearray|None):
+                A pre-allocated byte array to use for the framebuffer (rather than creating one on init).
+            needs_swap (bool):
+                Whether or not the RGB565 bytes must be swapped to show up correctly on the display.
+            **kwargs (Any):
+                Any other kwargs are captured and ignored.
+                This is an effort to allow any future/additional versions of this module to be more compatible.
+        """
         #init the fbuf
         if reserved_bytearray is None:
             # use_tiny_fbuf tells us to use a smaller framebuffer (4 bits per pixel rather than 16 bits)
@@ -47,7 +67,7 @@ class DisplayCore:
 
         self.palette = Palette()
         self.palette.use_tiny_buf = self.use_tiny_buf = use_tiny_buf
-        
+
         # keep track of min/max y vals for writing to display
         # this speeds up drawing significantly.
         # only y value is currently used, because framebuffer is stored in horizontal lines,
@@ -74,12 +94,11 @@ class DisplayCore:
 
 
     @micropython.viper
-    def _set_show_min(self, y0:int, y1:int):
+    def _set_show_min(self, y0: int, y1: int):
         """Set/store minimum and maximum Y to show next time show() is called."""
         y_min = int(self._show_y_min)
         y_max = int(self._show_y_max)
-        
-        
+
         if y_min > y0:
             y_min = y0
         if y_max < y1:
@@ -88,19 +107,17 @@ class DisplayCore:
         self._show_y_min = y_min
         self._show_y_max = y_max
 
-    
+
     @micropython.viper
-    def _format_color(self, color:int) -> int:
+    def _format_color(self, color: int) -> int:
         """Swap color bytes if needed, do nothing otherwise."""
         if (not self.use_tiny_buf) and self.needs_swap:
             color = ((color & 0xff) << 8) | (color >> 8)
         return color
 
 
-
-    def vline(self, x, y, length, color):
-        """
-        Draw vertical line at the given location and color.
+    def vline(self, x: int, y: int, length: int, color: int):
+        """Draw vertical line at the given location and color.
 
         Args:
             x (int): x coordinate
@@ -113,9 +130,8 @@ class DisplayCore:
         self.fbuf.vline(x, y, length, color)
 
 
-    def hline(self, x, y, length, color):
-        """
-        Draw horizontal line at the given location and color.
+    def hline(self, x: int, y: int, length: int, color: int):
+        """Draw horizontal line at the given location and color.
 
         Args:
             x (int): x coordinate
@@ -128,9 +144,8 @@ class DisplayCore:
         self.fbuf.hline(x, y, length, color)
 
 
-    def pixel(self, x, y, color):
-        """
-        Draw a pixel at the given location and color.
+    def pixel(self, x: int, y: int, color: int):
+        """Draw a pixel at the given location and color.
 
         Args:
             x (int): x coordinate
@@ -142,11 +157,8 @@ class DisplayCore:
         self.fbuf.pixel(x,y,color)
 
 
-
-
-    def rect(self, x, y, w, h, color, fill=False):
-        """
-        Draw a rectangle at the given location, size and color.
+    def rect(self, x: int, y: int, w: int, h: int, color: int, *, fill: bool = False):
+        """Draw a rectangle at the given location, size and color.
 
         Args:
             x (int): Top left corner x coordinate
@@ -160,9 +172,8 @@ class DisplayCore:
         self.fbuf.rect(x,y,w,h,color,fill)
 
 
-    def ellipse(self, x, y, xr, yr, color, fill=False, m=0xf):
-        """
-        Draw an ellipse at the given location, radius and color.
+    def ellipse(self, x:int, y:int, xr:int, yr:int, color:int, *, fill:bool=False, m:int=0xf):
+        """Draw an ellipse at the given location, radius and color.
 
         Args:
             x (int): Center x coordinate
@@ -177,27 +188,17 @@ class DisplayCore:
         self.fbuf.ellipse(x,y,xr,yr,color,fill,m)
 
 
-    def fill_rect(self, x, y, width, height, color):
-        """
-        Draw a rectangle at the given location, size and filled with color.
-        
-        This is just a wrapper for the rect() method,
-        and is provided for compatibility with the original st7789py driver.
+    def fill_rect(self, x:int, y:int, width:int, height:int, color:int):
+        """Draw a rectangle at the given location, size and filled with color.
 
-        Args:
-            x (int): Top left corner x coordinate
-            y (int): Top left corner y coordinate
-            width (int): Width in pixels
-            height (int): Height in pixels
-            color (int): 565 encoded color
+        This is just a wrapper for the rect() method,
+        and is provided for some compatibility with the original st7789py driver.
         """
-        self._set_show_min(y, y + height)
         self.rect(x, y, width, height, color, fill=True)
 
 
-    def fill(self, color):
-        """
-        Fill the entire FrameBuffer with the specified color.
+    def fill(self, color: int):
+        """Fill the entire FrameBuffer with the specified color.
 
         Args:
             color (int): 565 encoded color
@@ -208,7 +209,7 @@ class DisplayCore:
         self.fbuf.fill(color)
 
 
-    def line(self, x0, y0, x1, y1, color):
+    def line(self, x0: int, y0: int, x1: int, y1: int, color: int):
         """
         Draw a single pixel wide line starting at x0, y0 and ending at x1, y1.
 
@@ -221,19 +222,15 @@ class DisplayCore:
         """
         self._set_show_min(
             min(y0,y1),
-            max(y0,y1)
-            )
+            max(y0,y1),
+        )
         color = self._format_color(color)
         self.fbuf.line(x0, y0, x1, y1, color)
 
 
-    def scroll(self,xstep,ystep):
-        """
-        Shift the contents of the FrameBuffer by the given vector.
-        This may leave a footprint of the previous colors in the FrameBuffer.
+    def scroll(self, xstep: int, ystep: int):
+        """Shift the contents of the FrameBuffer by the given vector.
 
-        Unlike vscsad which uses the hardware for scrolling,
-        this method scrolls the framebuffer itself.
         This is a wrapper for the framebuffer.scroll method:
         """
         self._set_show_min(0, self.height)
@@ -242,16 +239,9 @@ class DisplayCore:
 
     @micropython.viper
     def _bitmap_text(self, font, text, x:int, y:int, color:int):
-        """
-        Internal viper method to draw text.
-        Designed to be envoked using the 'text' method.
+        """Quickly draw a text with a bitmap font using viper.
 
-        Args:
-            font (module): font module to use
-            text (str): text to write
-            x (int): column to start drawing at
-            y (int): row to start drawing at
-            color (int): encoded color to use for characters
+        Designed to be envoked using the 'text' method.
         """
         width = int(font.WIDTH)
         height = int(font.HEIGHT)
@@ -259,44 +249,43 @@ class DisplayCore:
         self_height = int(self.height)
 
         utf8_scale = height // 8
-        
+
         # early return for text off screen
         if y >= self_height or (y + height) < 0:
             return
-        
+
         glyphs = ptr8(font.FONT)
-        
+
         char_px_len = width * height
-        
+
         first = int(font.FIRST)
         last = int(font.LAST)
-        
-        
+
         use_tiny_fbuf = bool(self.use_tiny_buf)
         fbuf16 = ptr16(self.fbuf)
         fbuf8 = ptr8(self.fbuf)
-        
+
         for char in text:
             ch_idx = int(ord(char))
-            
+
             # only draw chars that exist in font
             if first <= ch_idx < last:
                 bit_start = (ch_idx - first) * char_px_len
-                
+
                 px_idx = 0
                 while px_idx < char_px_len:
                     byte_idx = (px_idx + bit_start) // 8
                     shift_amount = 7 - ((px_idx + bit_start) % 8)
-                    
+
                     target_x = x + px_idx % width
                     target_y = y + px_idx // width
-                    
+
                     # dont draw pixels off the screen (ptrs don't check your work!)
                     if ((glyphs[byte_idx] >> shift_amount) & 0x1) == 1 \
                     and 0 <= target_x < self_width \
                     and 0 <= target_y < self_height:
                         target_px = (target_y * self_width) + target_x
-                        
+
                         # I tried putting this if/else before px loop,
                         # surprisingly, there was not a noticable speed difference,
                         # and the code was harder to read. So, I put it back.
@@ -310,12 +299,12 @@ class DisplayCore:
                             # draw to 16 bits
                             target_idx = target_px
                             fbuf16[target_idx] = color
-                    
+
                     px_idx += 1
                 x += width
             else:
                 # try drawing with utf8 instead
-                x += int(self.utf8_putc(ch_idx, x, y, color, utf8_scale))
+                x += int(self._utf8_putc(ch_idx, x, y, color, utf8_scale))
 
             # early return for text off screen
             if x >= self_width:
@@ -323,14 +312,14 @@ class DisplayCore:
 
 
     @micropython.viper
-    def utf8_putc(self, char:int, x:int, y:int, color:int, scale:int) -> int:
-        """Render a single character on the screen."""
+    def _utf8_putc(self, char:int, x:int, y:int, color:int, scale:int) -> int:
+        """Render a single UTF8 character on the screen."""
         width = 4 if char < 128 else 8
         height = 8
 
         if not 0x0000 <= char <= 0xFFFF:
             return width * scale
-        
+
         # set up viper variables
         use_tiny_fbuf = bool(self.use_tiny_buf)
         fbuf16 = ptr16(self.fbuf)
@@ -369,7 +358,7 @@ class DisplayCore:
             # calculate x/y position from pixel index
             target_x = x + ((px_idx % width) * scale)
             target_y = y - ((px_idx // width) * scale)
-            
+
             if (cur[ptr_idx] >> shft_idx) & 1 == 1:
                 # iterate over x/y scale
                 scale_idx = 0
@@ -393,35 +382,34 @@ class DisplayCore:
                             fbuf16[target_idx] = color
                     scale_idx += 1
             px_idx += 1
-        
+
         # return x offset for drawing next char
         return width * scale
 
 
     @micropython.viper
     def _utf8_text(self, text, x:int, y:int, color:int):
-        """Draw text, including utf8 characters"""
+        """Draw text, including utf8 characters."""
         str_len = int(len(text))
-        
+
         idx = 0
         while idx < str_len:
             char = text[idx]
             ch_ord = int(ord(char))
             if ch_ord >= 128:
-                x += int(self.utf8_putc(ch_ord, x, y, color, 1))
+                x += int(self._utf8_putc(ch_ord, x, y, color, 1))
             else:
                 self.fbuf.text(char, x, y, color)
                 x += 8
             idx += 1
-        
 
-    def text(self, text, x, y, color, font=None):
-        """
-        Draw text to the framebuffer.
-        
+
+    def text(self, text: str, x: int, y: int, color: int, font=None):
+        """Draw text to the framebuffer.
+
         Text is drawn with no background.
-        If 'font' is None, uses the builtin framebuffer font.
-        
+        If 'font' is None, uses the built-in font.
+
         Args:
             text (str): text to write
             x (int): column to start drawing at
@@ -430,7 +418,6 @@ class DisplayCore:
             font (optional): bitmap font module to use
         """
         color = self._format_color(color)
-
 
         if font:
             self._set_show_min(y, y + font.HEIGHT)
@@ -442,7 +429,7 @@ class DisplayCore:
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~ Text Stuff:
     @staticmethod
-    def get_total_width(text: str, scale: int = 8) -> int:
+    def get_total_width(text: str, *, scale: int = 8) -> int:
         """Get the total width of a line (with UTF8 chars).
 
         Args:
@@ -450,6 +437,7 @@ class DisplayCore:
             scale (int): Optional width of each (single-width) character.
         """
         return DisplayCore._get_total_width(text, len(bytes(text, "utf-8")), scale)
+
 
     @staticmethod
     @micropython.viper
@@ -487,9 +475,14 @@ class DisplayCore:
         return total_width * scale
 
 
-    def bitmap(self, bitmap, x, y, index=0, key=-1, palette=None):
-        """
-        Draw a bitmap on display at the specified column and row
+    def bitmap(
+            self,bitmap, x: int,
+            y: int,
+            *,
+            index: int = 0,
+            key: int = -1,
+            palette: list[int]|None = None):
+        """Draw a bitmap on display at the specified column and row.
 
         Args:
             bitmap (bitmap_module): The module containing the bitmap to draw
@@ -501,31 +494,30 @@ class DisplayCore:
         """
         if self.width <= x or self.height <= y:
             return
-        
+
         if palette is None:
             palette = bitmap.PALETTE
-        
+
         self._bitmap(bitmap, x, y, index, key, palette)
 
 
     @micropython.viper
     def _bitmap(self, bitmap, x:int, y:int, index:int, key:int, palette):
-        
+
         width = int(bitmap.WIDTH)
         height = int(bitmap.HEIGHT)
         self_width = int(self.width)
         self_height = int(self.height)
-        
+
         palette_len = int(len(palette))
         bpp = int(bitmap.BPP)
         bitmap_pixels = height * width
         starting_bit = bpp * bitmap_pixels * index  # if index > 0 else 0
-        
+
         use_tiny_buf = bool(self.use_tiny_buf)
-        
+
         self._set_show_min(y, y + height)
-        
-        
+
         # format color palette into a pointer
         palette_buf = bytearray(palette_len * 2)
         palette_ptr = ptr16(palette_buf)
@@ -534,35 +526,35 @@ class DisplayCore:
                 self._format_color(palette[i])
                 )
         key = int(self._format_color(key))
-        
-        bitmap_ptr = ptr8(bitmap._bitmap)
+
+        bitmap_ptr = ptr8(bitmap.BITMAP)
         fbuf8 = ptr8(self.fbuf)
         fbuf16 = ptr16(self.fbuf)
-        
+
         bitmask = 0xffff >> (16 - bpp)
-        
+
         # iterate over pixels
         px_idx = 0
         while px_idx < bitmap_pixels:
             source_bit = (px_idx * bpp) + starting_bit
             source_idx = source_bit // 8 
             source_shift = 7 - (source_bit % 8)
-            
+
             # bitmap value is an index in the color palette
             source = (bitmap_ptr[source_idx] >> source_shift) & bitmask
             clr = palette_ptr[source]
-            
+
             target_x = x + px_idx % width
             target_y = y + px_idx // width
-            
+
             # dont draw pixels off the screen (ptrs don't check your work!)
             if clr != key \
             and 0 <= target_x < self_width \
             and 0 <= target_y < self_height:
-                
+
                 # convert px coordinate to an index
                 target_px = (target_y * self_width) + target_x
-                
+
                 if use_tiny_buf:
                     # writing 4-bit pixels
                     target_idx = target_px // 2
@@ -570,17 +562,15 @@ class DisplayCore:
                     dest_mask = 0xf0 >> dest_shift
                     fbuf8[target_idx] = (fbuf8[target_idx] & dest_mask) | (clr << dest_shift)
                 else:
-                    # TODO: TEST THIS! (has only been tested for tiny fbuf)
                     # writing 16-bit pixels
                     target_idx = target_px
                     fbuf16[target_idx] = clr
-            
+
             px_idx += 1
 
 
-    def polygon(self, coords, x, y, color, fill=False):
-        """
-        Draw a polygon from an array of coordinates
+    def polygon(self, coords, x: int, y: int, color: int, *, fill: bool = False):
+        """Draw a polygon from an array of coordinates.
 
         Args:
             coords (array('h')): An array of x/y coordinates defining the shape
@@ -595,13 +585,21 @@ class DisplayCore:
         color = self._format_color(color)
         self.fbuf.poly(x, y, coords, color, fill)
 
-        
-    def blit_buffer(self, buffer, x, y, width, height, key=-1, palette=None):
-        """
-        Copy buffer to display framebuf at the given location.
+
+    def blit_buffer(
+            self,
+            buffer: bytearray|framebuf.FrameBuffer,
+            x: int,
+            y: int,
+            width: int,
+            height: int,
+            *,
+            key: int = -1,
+            palette: framebuf.FrameBuffer|None = None):
+        """Copy buffer to display framebuf at the given location.
 
         Args:
-            buffer (bytes): Data to copy to display
+            buffer (bytearray): Data to copy to display
             x (int): Top left corner x coordinate
             Y (int): Top left corner y coordinate
             width (int): Width
@@ -615,6 +613,5 @@ class DisplayCore:
                 buffer, width, height,
                 framebuf.GS4_HMSB if self.use_tiny_buf else framebuf.RGB565,
                 )
-        
-        self.fbuf.blit(buffer, x, y, key, palette)
 
+        self.fbuf.blit(buffer, x, y, key, palette)

--- a/src/lib/display/displaycore.py
+++ b/src/lib/display/displaycore.py
@@ -1,0 +1,620 @@
+"""The heart of MicroHydra graphics functionality."""
+
+
+import framebuf
+from .palette import Palette
+from lib.hydra.utils import get_instance
+
+# mh_if frozen:
+# # frozen firmware must access the font as a module,
+# # rather than a binary file.
+# from font.utf8_8x8 import utf8
+# mh_end_if
+
+
+
+class DisplayCore:
+    """The core graphical functionality for the Display module."""
+
+    def __init__(
+            self,
+            width,
+            height,
+            rotation=0,
+            use_tiny_buf=False,
+            reserved_bytearray=None,
+            needs_swap=True,
+            **kwargs):
+        #init the fbuf
+        if reserved_bytearray is None:
+            # use_tiny_fbuf tells us to use a smaller framebuffer (4 bits per pixel rather than 16 bits)
+            if use_tiny_buf:
+                # round width up to 8 bits
+                size = (height * width) // 2 if (width % 8 == 0) else (height * (width + 1)) // 2
+                reserved_bytearray = bytearray(size)
+
+            else: # full sized buffer
+                reserved_bytearray = bytearray(height*width*2)
+
+        self.fbuf = framebuf.FrameBuffer(
+            reserved_bytearray,
+            # height and width are swapped when rotation is 1 or 3
+            height if (rotation % 2 == 1) else width,
+            width if (rotation % 2 == 1) else height,
+            # use_tiny_fbuf uses GS4 format for less memory usage
+            framebuf.GS4_HMSB if use_tiny_buf else framebuf.RGB565,
+            )
+
+        self.palette = Palette()
+        self.palette.use_tiny_buf = self.use_tiny_buf = use_tiny_buf
+        
+        # keep track of min/max y vals for writing to display
+        # this speeds up drawing significantly.
+        # only y value is currently used, because framebuffer is stored in horizontal lines,
+        # making y slices much simpler than x slices.
+        self._show_y_min = width if (rotation % 2 == 1) else height
+        self._show_y_max = 0
+
+        self.width = width
+        self.height = height
+        self.needs_swap = needs_swap
+
+
+
+    def _reset_show_min(self) -> tuple[int, int]:
+        """Return and reset y boundaries."""
+        # clamp min and max
+        y_min = max(self._show_y_min, 0)
+        y_max = min(self._show_y_max, self.height)
+
+        self._show_y_min = self.height
+        self._show_y_max = 0
+
+        return y_min, y_max
+
+
+    @micropython.viper
+    def _set_show_min(self, y0:int, y1:int):
+        """Set/store minimum and maximum Y to show next time show() is called."""
+        y_min = int(self._show_y_min)
+        y_max = int(self._show_y_max)
+        
+        
+        if y_min > y0:
+            y_min = y0
+        if y_max < y1:
+            y_max = y1
+
+        self._show_y_min = y_min
+        self._show_y_max = y_max
+
+    
+    @micropython.viper
+    def _format_color(self, color:int) -> int:
+        """Swap color bytes if needed, do nothing otherwise."""
+        if (not self.use_tiny_buf) and self.needs_swap:
+            color = ((color & 0xff) << 8) | (color >> 8)
+        return color
+
+
+
+    def vline(self, x, y, length, color):
+        """
+        Draw vertical line at the given location and color.
+
+        Args:
+            x (int): x coordinate
+            Y (int): y coordinate
+            length (int): length of line
+            color (int): 565 encoded color
+        """
+        self._set_show_min(y, y + length)
+        color = self._format_color(color)
+        self.fbuf.vline(x, y, length, color)
+
+
+    def hline(self, x, y, length, color):
+        """
+        Draw horizontal line at the given location and color.
+
+        Args:
+            x (int): x coordinate
+            Y (int): y coordinate
+            length (int): length of line
+            color (int): 565 encoded color
+        """
+        self._set_show_min(y, y)
+        color = self._format_color(color)
+        self.fbuf.hline(x, y, length, color)
+
+
+    def pixel(self, x, y, color):
+        """
+        Draw a pixel at the given location and color.
+
+        Args:
+            x (int): x coordinate
+            Y (int): y coordinate
+            color (int): 565 encoded color
+        """
+        self._set_show_min(y, y)
+        color = self._format_color(color)
+        self.fbuf.pixel(x,y,color)
+
+
+
+
+    def rect(self, x, y, w, h, color, fill=False):
+        """
+        Draw a rectangle at the given location, size and color.
+
+        Args:
+            x (int): Top left corner x coordinate
+            y (int): Top left corner y coordinate
+            width (int): Width in pixels
+            height (int): Height in pixels
+            color (int): 565 encoded color
+        """
+        self._set_show_min(y, y + h)
+        color = self._format_color(color)
+        self.fbuf.rect(x,y,w,h,color,fill)
+
+
+    def ellipse(self, x, y, xr, yr, color, fill=False, m=0xf):
+        """
+        Draw an ellipse at the given location, radius and color.
+
+        Args:
+            x (int): Center x coordinate
+            y (int): Center y coordinate
+            xr (int): x axis radius
+            yr (int): y axis radius
+            color (int): 565 encoded color
+            fill (bool): fill in the ellipse. Default is False
+        """
+        self._set_show_min(y - yr, y + yr + 1)
+        color = self._format_color(color)
+        self.fbuf.ellipse(x,y,xr,yr,color,fill,m)
+
+
+    def fill_rect(self, x, y, width, height, color):
+        """
+        Draw a rectangle at the given location, size and filled with color.
+        
+        This is just a wrapper for the rect() method,
+        and is provided for compatibility with the original st7789py driver.
+
+        Args:
+            x (int): Top left corner x coordinate
+            y (int): Top left corner y coordinate
+            width (int): Width in pixels
+            height (int): Height in pixels
+            color (int): 565 encoded color
+        """
+        self._set_show_min(y, y + height)
+        self.rect(x, y, width, height, color, fill=True)
+
+
+    def fill(self, color):
+        """
+        Fill the entire FrameBuffer with the specified color.
+
+        Args:
+            color (int): 565 encoded color
+        """
+        # whole display must show
+        self._set_show_min(0, self.height)
+        color = self._format_color(color)
+        self.fbuf.fill(color)
+
+
+    def line(self, x0, y0, x1, y1, color):
+        """
+        Draw a single pixel wide line starting at x0, y0 and ending at x1, y1.
+
+        Args:
+            x0 (int): Start point x coordinate
+            y0 (int): Start point y coordinate
+            x1 (int): End point x coordinate
+            y1 (int): End point y coordinate
+            color (int): 565 encoded color
+        """
+        self._set_show_min(
+            min(y0,y1),
+            max(y0,y1)
+            )
+        color = self._format_color(color)
+        self.fbuf.line(x0, y0, x1, y1, color)
+
+
+    def scroll(self,xstep,ystep):
+        """
+        Shift the contents of the FrameBuffer by the given vector.
+        This may leave a footprint of the previous colors in the FrameBuffer.
+
+        Unlike vscsad which uses the hardware for scrolling,
+        this method scrolls the framebuffer itself.
+        This is a wrapper for the framebuffer.scroll method:
+        """
+        self._set_show_min(0, self.height)
+        self.fbuf.scroll(xstep,ystep)
+
+
+    @micropython.viper
+    def _bitmap_text(self, font, text, x:int, y:int, color:int):
+        """
+        Internal viper method to draw text.
+        Designed to be envoked using the 'text' method.
+
+        Args:
+            font (module): font module to use
+            text (str): text to write
+            x (int): column to start drawing at
+            y (int): row to start drawing at
+            color (int): encoded color to use for characters
+        """
+        width = int(font.WIDTH)
+        height = int(font.HEIGHT)
+        self_width = int(self.width)
+        self_height = int(self.height)
+
+        utf8_scale = height // 8
+        
+        # early return for text off screen
+        if y >= self_height or (y + height) < 0:
+            return
+        
+        glyphs = ptr8(font.FONT)
+        
+        char_px_len = width * height
+        
+        first = int(font.FIRST)
+        last = int(font.LAST)
+        
+        
+        use_tiny_fbuf = bool(self.use_tiny_buf)
+        fbuf16 = ptr16(self.fbuf)
+        fbuf8 = ptr8(self.fbuf)
+        
+        for char in text:
+            ch_idx = int(ord(char))
+            
+            # only draw chars that exist in font
+            if first <= ch_idx < last:
+                bit_start = (ch_idx - first) * char_px_len
+                
+                px_idx = 0
+                while px_idx < char_px_len:
+                    byte_idx = (px_idx + bit_start) // 8
+                    shift_amount = 7 - ((px_idx + bit_start) % 8)
+                    
+                    target_x = x + px_idx % width
+                    target_y = y + px_idx // width
+                    
+                    # dont draw pixels off the screen (ptrs don't check your work!)
+                    if ((glyphs[byte_idx] >> shift_amount) & 0x1) == 1 \
+                    and 0 <= target_x < self_width \
+                    and 0 <= target_y < self_height:
+                        target_px = (target_y * self_width) + target_x
+                        
+                        # I tried putting this if/else before px loop,
+                        # surprisingly, there was not a noticable speed difference,
+                        # and the code was harder to read. So, I put it back.
+                        if use_tiny_fbuf:
+                            # pack 4 bits into 8 bit ptr
+                            target_idx = target_px // 2
+                            dest_shift = ((target_px + 1) % 2) * 4
+                            dest_mask = 0xf0 >> dest_shift
+                            fbuf8[target_idx] = (fbuf8[target_idx] & dest_mask) | (color << dest_shift)
+                        else:
+                            # draw to 16 bits
+                            target_idx = target_px
+                            fbuf16[target_idx] = color
+                    
+                    px_idx += 1
+                x += width
+            else:
+                # try drawing with utf8 instead
+                x += int(self.utf8_putc(ch_idx, x, y, color, utf8_scale))
+
+            # early return for text off screen
+            if x >= self_width:
+                return
+
+
+    @micropython.viper
+    def utf8_putc(self, char:int, x:int, y:int, color:int, scale:int) -> int:
+        """Render a single character on the screen."""
+        width = 4 if char < 128 else 8
+        height = 8
+
+        if not 0x0000 <= char <= 0xFFFF:
+            return width * scale
+        
+        # set up viper variables
+        use_tiny_fbuf = bool(self.use_tiny_buf)
+        fbuf16 = ptr16(self.fbuf)
+        fbuf8 = ptr8(self.fbuf)
+        self_width = int(self.width)
+        self_height = int(self.height)
+
+        # calculate the offset in the binary data
+        offset = char * 8
+
+        # mh_if frozen:
+        # # Read the font data directly from the memoryview
+        # cur = ptr8(utf8)
+        # mh_else:
+        # seek to offset and read 8 bytes
+        self.utf8_font.seek(offset)
+        cur = ptr8(self.utf8_font.read(8))
+        # mh_end_if
+
+        # y axis is inverted - we start from bottom not top
+        y += (height - 1) * scale - 1
+
+        # iterate over every character pixel
+        px_idx = 0
+        max_px_idx = width * height
+        while px_idx < max_px_idx:
+            # which byte to fetch from the ptr8,
+            # and how far to shift (to get 1 bit)
+            ptr_idx = px_idx // 8
+            shft_idx = px_idx % 8
+            # mh_if frozen:
+            # # if reading from memoryview, add offset now
+            # ptr_idx += offset
+            # mh_end_if
+
+            # calculate x/y position from pixel index
+            target_x = x + ((px_idx % width) * scale)
+            target_y = y - ((px_idx // width) * scale)
+            
+            if (cur[ptr_idx] >> shft_idx) & 1 == 1:
+                # iterate over x/y scale
+                scale_idx = 0
+                num_scale_pixels = scale * scale
+                while scale_idx < num_scale_pixels:
+                    xsize = scale_idx % scale
+                    ysize = scale_idx // scale
+
+                    target_px = ((target_y + ysize) * self_width) + target_x + xsize
+                    if 0 <= (target_x + xsize) < self_width \
+                    and 0 <= (target_y + ysize) < self_height:
+                        if use_tiny_fbuf:
+                            # pack 4 bits into 8 bit ptr
+                            target_idx = target_px // 2
+                            dest_shift = ((target_px + 1) % 2) * 4
+                            dest_mask = 0xf0 >> dest_shift
+                            fbuf8[target_idx] = (fbuf8[target_idx] & dest_mask) | (color << dest_shift)
+                        else:
+                            # draw to 16 bits
+                            target_idx = target_px
+                            fbuf16[target_idx] = color
+                    scale_idx += 1
+            px_idx += 1
+        
+        # return x offset for drawing next char
+        return width * scale
+
+
+    @micropython.viper
+    def _utf8_text(self, text, x:int, y:int, color:int):
+        """Draw text, including utf8 characters"""
+        str_len = int(len(text))
+        
+        idx = 0
+        while idx < str_len:
+            char = text[idx]
+            ch_ord = int(ord(char))
+            if ch_ord >= 128:
+                x += int(self.utf8_putc(ch_ord, x, y, color, 1))
+            else:
+                self.fbuf.text(char, x, y, color)
+                x += 8
+            idx += 1
+        
+
+    def text(self, text, x, y, color, font=None):
+        """
+        Draw text to the framebuffer.
+        
+        Text is drawn with no background.
+        If 'font' is None, uses the builtin framebuffer font.
+        
+        Args:
+            text (str): text to write
+            x (int): column to start drawing at
+            y (int): row to start drawing at
+            color (int): encoded color to use for text
+            font (optional): bitmap font module to use
+        """
+        color = self._format_color(color)
+
+
+        if font:
+            self._set_show_min(y, y + font.HEIGHT)
+            self._bitmap_text(font, text, x, y, color)
+        else:
+            self._set_show_min(y, y + 8)
+            self._utf8_text(text, x, y, color)
+
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~ Text Stuff:
+    @staticmethod
+    def get_total_width(text: str, scale: int = 8) -> int:
+        """Get the total width of a line (with UTF8 chars).
+
+        Args:
+            text (str): The text string to measure.
+            scale (int): Optional width of each (single-width) character.
+        """
+        return DisplayCore._get_total_width(text, len(bytes(text, "utf-8")), scale)
+
+    @staticmethod
+    @micropython.viper
+    def _get_total_width(text_ptr: ptr8, text_len: int, scale: int) -> int:
+        """Fast viper component of get_total_width.
+
+        Scans over raw string bytes to count number of single-byte or multi-byte characters.
+        Saves a lot of time by not fully decoding any code-points,
+        and by skipping function call overhead from `ord`.
+        """
+        total_width = 0
+        idx = 0
+        while idx < text_len:
+            # count leading 1's to determine byte type
+            # 0 = Single Byte, 1 = continuation byte
+            # 2-4 = Start byte (stop testing after 2)
+            leading_bytes = 0
+            byte_shift = 7
+            while leading_bytes < 2:
+                if text_ptr[idx] >> byte_shift & 1:
+                    leading_bytes += 1
+                    byte_shift -= 1
+                else:
+                    break
+
+            # single byte chars have width 8, others have width 16
+            # ignore continuation bytes.
+            if leading_bytes == 0:  # single byte char
+                total_width += 1
+            elif leading_bytes > 1:  # multi byte char
+                total_width += 2
+
+            idx += 1
+
+        return total_width * scale
+
+
+    def bitmap(self, bitmap, x, y, index=0, key=-1, palette=None):
+        """
+        Draw a bitmap on display at the specified column and row
+
+        Args:
+            bitmap (bitmap_module): The module containing the bitmap to draw
+            x (int): column to start drawing at
+            y (int): row to start drawing at
+            index (int): Optional index of bitmap to draw from multiple bitmap
+                module
+            key (int): colors that match the key will be transparent.
+        """
+        if self.width <= x or self.height <= y:
+            return
+        
+        if palette is None:
+            palette = bitmap.PALETTE
+        
+        self._bitmap(bitmap, x, y, index, key, palette)
+
+
+    @micropython.viper
+    def _bitmap(self, bitmap, x:int, y:int, index:int, key:int, palette):
+        
+        width = int(bitmap.WIDTH)
+        height = int(bitmap.HEIGHT)
+        self_width = int(self.width)
+        self_height = int(self.height)
+        
+        palette_len = int(len(palette))
+        bpp = int(bitmap.BPP)
+        bitmap_pixels = height * width
+        starting_bit = bpp * bitmap_pixels * index  # if index > 0 else 0
+        
+        use_tiny_buf = bool(self.use_tiny_buf)
+        
+        self._set_show_min(y, y + height)
+        
+        
+        # format color palette into a pointer
+        palette_buf = bytearray(palette_len * 2)
+        palette_ptr = ptr16(palette_buf)
+        for i in range(palette_len):
+            palette_ptr[i] = int(
+                self._format_color(palette[i])
+                )
+        key = int(self._format_color(key))
+        
+        bitmap_ptr = ptr8(bitmap._bitmap)
+        fbuf8 = ptr8(self.fbuf)
+        fbuf16 = ptr16(self.fbuf)
+        
+        bitmask = 0xffff >> (16 - bpp)
+        
+        # iterate over pixels
+        px_idx = 0
+        while px_idx < bitmap_pixels:
+            source_bit = (px_idx * bpp) + starting_bit
+            source_idx = source_bit // 8 
+            source_shift = 7 - (source_bit % 8)
+            
+            # bitmap value is an index in the color palette
+            source = (bitmap_ptr[source_idx] >> source_shift) & bitmask
+            clr = palette_ptr[source]
+            
+            target_x = x + px_idx % width
+            target_y = y + px_idx // width
+            
+            # dont draw pixels off the screen (ptrs don't check your work!)
+            if clr != key \
+            and 0 <= target_x < self_width \
+            and 0 <= target_y < self_height:
+                
+                # convert px coordinate to an index
+                target_px = (target_y * self_width) + target_x
+                
+                if use_tiny_buf:
+                    # writing 4-bit pixels
+                    target_idx = target_px // 2
+                    dest_shift = ((target_px + 1) % 2) * 4
+                    dest_mask = 0xf0 >> dest_shift
+                    fbuf8[target_idx] = (fbuf8[target_idx] & dest_mask) | (clr << dest_shift)
+                else:
+                    # TODO: TEST THIS! (has only been tested for tiny fbuf)
+                    # writing 16-bit pixels
+                    target_idx = target_px
+                    fbuf16[target_idx] = clr
+            
+            px_idx += 1
+
+
+    def polygon(self, coords, x, y, color, fill=False):
+        """
+        Draw a polygon from an array of coordinates
+
+        Args:
+            coords (array('h')): An array of x/y coordinates defining the shape
+            x (int): column to start drawing at
+            y (int): row to start drawing at
+            color (int): Color of polygon
+            fill (bool=False) : fill the polygon (or draw an outline)
+        """
+        # calculate approx height so min/max can be set
+        h = max(coords)
+        self._set_show_min(y, y + h)
+        color = self._format_color(color)
+        self.fbuf.poly(x, y, coords, color, fill)
+
+        
+    def blit_buffer(self, buffer, x, y, width, height, key=-1, palette=None):
+        """
+        Copy buffer to display framebuf at the given location.
+
+        Args:
+            buffer (bytes): Data to copy to display
+            x (int): Top left corner x coordinate
+            Y (int): Top left corner y coordinate
+            width (int): Width
+            height (int): Height
+            key (int): color to be considered transparent
+            palette (framebuf): the color pallete to use for the buffer
+        """
+        self._set_show_min(y, y + height)
+        if not isinstance(buffer, framebuf.FrameBuffer):
+            buffer = framebuf.FrameBuffer(
+                buffer, width, height,
+                framebuf.GS4_HMSB if self.use_tiny_buf else framebuf.RGB565,
+                )
+        
+        self.fbuf.blit(buffer, x, y, key, palette)
+

--- a/src/lib/display/displaycore.py
+++ b/src/lib/display/displaycore.py
@@ -82,7 +82,7 @@ class DisplayCore:
 
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ DisplayCore utils: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    def _reset_show_min(self) -> tuple[int, int]:
+    def reset_show_y(self) -> tuple[int, int]:
         """Return and reset y boundaries."""
         # clamp min and max
         y_min = max(self._show_y_min, 0)
@@ -95,7 +95,7 @@ class DisplayCore:
 
 
     @micropython.viper
-    def _set_show_min(self, y0: int, y1: int):
+    def _set_show_y(self, y0: int, y1: int):
         """Set/store minimum and maximum Y to show next time show() is called."""
         y_min = int(self._show_y_min)
         y_max = int(self._show_y_max)
@@ -115,6 +115,7 @@ class DisplayCore:
         if (not self.use_tiny_buf) and self.needs_swap:
             color = ((color & 0xff) << 8) | (color >> 8)
         return color
+
 
     def blit_buffer(
             self,
@@ -137,7 +138,7 @@ class DisplayCore:
             key (int): color to be considered transparent
             palette (framebuf): the color pallete to use for the buffer
         """
-        self._set_show_min(y, y + height)
+        self._set_show_y(y, y + height)
         if not isinstance(buffer, framebuf.FrameBuffer):
             buffer = framebuf.FrameBuffer(
                 buffer, width, height,
@@ -157,7 +158,7 @@ class DisplayCore:
             color (int): 565 encoded color
         """
         # whole display must show
-        self._set_show_min(0, self.height)
+        self._set_show_y(0, self.height)
         color = self._format_color(color)
         self.fbuf.fill(color)
 
@@ -170,7 +171,7 @@ class DisplayCore:
             Y (int): y coordinate
             color (int): 565 encoded color
         """
-        self._set_show_min(y, y)
+        self._set_show_y(y, y)
         color = self._format_color(color)
         self.fbuf.pixel(x,y,color)
 
@@ -184,7 +185,7 @@ class DisplayCore:
             length (int): length of line
             color (int): 565 encoded color
         """
-        self._set_show_min(y, y + length)
+        self._set_show_y(y, y + length)
         color = self._format_color(color)
         self.fbuf.vline(x, y, length, color)
 
@@ -198,7 +199,7 @@ class DisplayCore:
             length (int): length of line
             color (int): 565 encoded color
         """
-        self._set_show_min(y, y)
+        self._set_show_y(y, y)
         color = self._format_color(color)
         self.fbuf.hline(x, y, length, color)
 
@@ -214,7 +215,7 @@ class DisplayCore:
             y1 (int): End point y coordinate
             color (int): 565 encoded color
         """
-        self._set_show_min(
+        self._set_show_y(
             min(y0,y1),
             max(y0,y1),
         )
@@ -232,7 +233,7 @@ class DisplayCore:
             height (int): Height in pixels
             color (int): 565 encoded color
         """
-        self._set_show_min(y, y + h)
+        self._set_show_y(y, y + h)
         color = self._format_color(color)
         self.fbuf.rect(x,y,w,h,color,fill)
 
@@ -257,7 +258,7 @@ class DisplayCore:
             color (int): 565 encoded color
             fill (bool): fill in the ellipse. Default is False
         """
-        self._set_show_min(y - yr, y + yr + 1)
+        self._set_show_y(y - yr, y + yr + 1)
         color = self._format_color(color)
         self.fbuf.ellipse(x,y,xr,yr,color,fill,m)
 
@@ -274,7 +275,7 @@ class DisplayCore:
         """
         # calculate approx height so min/max can be set
         h = max(coords)
-        self._set_show_min(y, y + h)
+        self._set_show_y(y, y + h)
         color = self._format_color(color)
         self.fbuf.poly(x, y, coords, color, fill)
 
@@ -284,7 +285,7 @@ class DisplayCore:
 
         This is a wrapper for the framebuffer.scroll method.
         """
-        self._set_show_min(0, self.height)
+        self._set_show_y(0, self.height)
         self.fbuf.scroll(xstep,ystep)
 
 
@@ -307,10 +308,10 @@ class DisplayCore:
         color = self._format_color(color)
 
         if font:
-            self._set_show_min(y, y + font.HEIGHT)
+            self._set_show_y(y, y + font.HEIGHT)
             self._bitmap_text(font, text, x, y, color)
         else:
-            self._set_show_min(y, y + 8)
+            self._set_show_y(y, y + 8)
             self._utf8_text(text, x, y, color)
 
 
@@ -572,7 +573,7 @@ class DisplayCore:
 
         use_tiny_buf = bool(self.use_tiny_buf)
 
-        self._set_show_min(y, y + height)
+        self._set_show_y(y, y + height)
 
         # format color palette into a pointer
         palette_buf = bytearray(palette_len * 2)

--- a/src/lib/display/st7789.py
+++ b/src/lib/display/st7789.py
@@ -40,22 +40,6 @@ This driver supports:
 - 320x240, 240x240, 135x240 and 128x128 pixel displays
 - Display rotation
 - RGB and BGR color orders
-- Hardware based scrolling
-- Drawing text using 8 and 16 bit wide bitmap fonts with heights that are
-  multiples of 8.  Included are 12 bitmap fonts derived from classic pc
-  BIOS text mode fonts.
-- Drawing converted bitmaps
-- Named color constants
-
-  - BLACK
-  - BLUE
-  - RED
-  - GREEN
-  - CYAN
-  - MAGENTA
-  - YELLOW
-  - WHITE
-
 """
 
 import struct
@@ -480,7 +464,7 @@ class ST7789(DisplayCore):
         # mh_end_if
 
         # Reset and clamp min/max vals
-        y_min, y_max = self._reset_show_min()
+        y_min, y_max = self.reset_show_y()
 
         if y_min >= y_max:
             # nothing to show

--- a/src/lib/display/st7789.py
+++ b/src/lib/display/st7789.py
@@ -161,12 +161,6 @@ _DISPLAY_128x128 = const((
     (0xc0, 128, 128, 2, 1),
     (0xa0, 128, 128, 1, 2)))
 
-# index values into rotation table
-_WIDTH = const(0)
-_HEIGHT = const(1)
-_XSTART = const(2)
-_YSTART = const(3)
-
 # Supported displays (physical width, physical height, rotation table)
 _SUPPORTED_DISPLAYS = const((
     (240, 320, _DISPLAY_240x320),
@@ -272,7 +266,6 @@ class ST7789(DisplayCore):
                 return display[2]
         msg = f"{width}x{height} display. Not in `_SUPPORTED_DISPLAYS`"
         raise ValueError(msg)
-
 
 
     def init(self, commands: tuple):
@@ -405,7 +398,7 @@ class ST7789(DisplayCore):
         # mh_end_if
 
 
-    def inversion_mode(self, value):
+    def inversion_mode(self, value: bool):
         """
         Enable or disable display inversion mode.
 


### PR DESCRIPTION
Split st7789 drawing methods into separate displaycore module. 

**BREAKING**: This change slightly modifies some method signatures in the display module (Some args are now keyword-only args), as well as heavily modifies some private methods from the st7789 module. Hopefully, neither of these changes will actually cause problems, in practice.

st7789.py will now be purely a driver for the display. Ideally, new drivers will be able to be created in the future, and can use the same displaycore.py base for all their graphics functions.

This resolves #146 